### PR TITLE
Support custom equality function

### DIFF
--- a/README.md
+++ b/README.md
@@ -433,7 +433,7 @@ Time.assertEqual(
 Time.run(err => console.error(err));
 ```
 
-You can optionally pass a custom comparator function.
+You can optionally pass a custom comparator function. This is useful if you want to do things like testing your DOM with tools such as [html-looks-like](https://github.com/staltz/html-looks-like).
 
 ```js
 // passes

--- a/README.md
+++ b/README.md
@@ -408,7 +408,7 @@ Time.run();
 // baz
 ```
 
-#### `assertEqual(actualStream, expectedStream, done)`
+#### `assertEqual(actualStream, expectedStream, comparator = assert.deepEqual)`
 Can be used to assert two streams are equivalent. This is useful when combine with `.diagram` for creating tests.
 
 ```js
@@ -431,6 +431,41 @@ Time.assertEqual(
 Time.run(err => console.error(err));
 ```
 
+You can optionally pass a custom comparator function.
+
+```js
+// passes
+
+const expected = Time.diagram(
+  `---A---B---C---|`,
+  {
+    A: {foo: 1, bar: 4},
+    B: {foo: 2, bar: 5},
+    C: {foo: 3, bar: 6}
+  }
+);
+
+const actual = Time.diagram(
+  `---A---B---C---|`,
+  {
+    A: {foo: 0, bar: 4},
+    B: {foo: 5, bar: 5},
+    C: {foo: 8, bar: 6}
+  }
+);
+
+function comparator (expected, actual) {
+  return expected.bar === actual.bar;
+}
+
+Time.assertEqual(
+  expected,
+  actual,
+  comparator
+);
+
+Time.run();
+```
 ## License
 
 MIT

--- a/README.md
+++ b/README.md
@@ -311,10 +311,10 @@ Returns a stream that emits every `period` msec. Starts with zero and increases 
 
 ```js
 const actual$ = Time.periodic(80);
-const expected$ = Time.diagram(`---0---1---2---3---4|`);
+const expected$ = Time.diagram(`----0---1---2---3-`);
 
 Time.assertEqual(
-  actual$.take(5),
+  actual$,
   expected$
 );
 
@@ -420,7 +420,9 @@ Time.assertEqual(
 );
 
 Time.run();
-
+```
+<!-- skip-example -->
+```js
 // fails
 
 Time.assertEqual(

--- a/README.md
+++ b/README.md
@@ -435,6 +435,24 @@ Time.run(err => console.error(err));
 
 You can optionally pass a custom comparator function. This is useful if you want to do things like testing your DOM with tools such as [html-looks-like](https://github.com/staltz/html-looks-like).
 
+A custom comparator function should take two arguments: `actual`, and `expected`. It can either return a boolean, or throw an error. If an error is thrown, it will be shown in the error log.
+
+```js
+// returns a boolean
+
+function comparator (actual, expected) {
+  return actual.foo === expected.foo;
+}
+
+// throws an error
+
+function comparator (actual, expected) {
+  if (actual.foo !== expected.foo) {
+    throw new Error(`${actual.foo} should be the same as ${expected.foo}`);
+  }
+}
+```
+
 ```js
 // passes
 
@@ -456,13 +474,13 @@ const actual = Time.diagram(
   }
 );
 
-function comparator (expected, actual) {
-  return expected.bar === actual.bar;
+function comparator (actual, expected) {
+  return actual.bar === expected.bar;
 }
 
 Time.assertEqual(
-  expected,
   actual,
+  expected,
   comparator
 );
 

--- a/package.json
+++ b/package.json
@@ -51,7 +51,6 @@
     "budo": "^9.2.2",
     "garnish": "^5.2.0",
     "greenkeeper-postpublish": "^1.0.1",
-    "html-looks-like": "^1.0.2",
     "markdown-doctest": "^0.9.1",
     "mocha": "^3.1.2",
     "most": "^1.2.2",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
   "dependencies": {
     "@cycle/run": "^1.0.0-rc.9",
     "combine-errors": "^3.0.3",
-    "deep-equal": "^1.0.1",
     "raf": "^3.3.0",
     "setimmediate": "^1.0.5",
     "sorted-immutable-list": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "budo": "^9.2.2",
     "garnish": "^5.2.0",
     "greenkeeper-postpublish": "^1.0.1",
+    "html-looks-like": "^1.0.2",
     "markdown-doctest": "^0.9.1",
     "mocha": "^3.1.2",
     "most": "^1.2.2",

--- a/src/assert-equal.ts
+++ b/src/assert-equal.ts
@@ -58,10 +58,13 @@ function checkEqual (completeStore, assert, interval, comparator) {
       if (!rightTime || !rightValue) {
         const errorMessage = [
           `Expected value at time ${expected.time} but got different value at ${actual.time}\n`,
-          `Expected ${JSON.stringify(expected.value)}, got ${JSON.stringify(actual.value)}`
         ];
 
-        if (!usingCustomComparator) {
+        if (usingCustomComparator) {
+          const message = `Expected ${JSON.stringify(expected.value)}, got ${JSON.stringify(actual.value)}`
+
+          errorMessage.push(message);
+        } else {
           const diffMessage = [
             `Diff (actual => expected):`,
             variableDiff(actual.value, expected.value).text

--- a/src/time-source.ts
+++ b/src/time-source.ts
@@ -2,6 +2,7 @@ import {Stream} from 'xstream';
 import {Frame} from './animation-frames';
 
 export type Operator = <T>(stream: Stream<T>) => Stream<T>;
+export type Comparator = (actual: any, expected: any) => void;
 
 export interface TimeSource {
   animationFrames (): Stream<Frame>;
@@ -15,6 +16,6 @@ export interface TimeSource {
 export interface MockTimeSource extends TimeSource {
   diagram (str: string, values?: Object): Stream<any>;
   record (stream: Stream<any>): Stream<Array<any>>;
-  assertEqual (actual: Stream<any>, expected: Stream<any>): void;
+  assertEqual (actual: Stream<any>, expected: Stream<any>, comparator?: Comparator): void;
   run (cb?: (err?: Error) => void): void;
 }

--- a/test/time.ts
+++ b/test/time.ts
@@ -285,7 +285,7 @@ describe("@cycle/time", () => {
             Time.run(done);
           });
 
-          it("compares objects using deep equality", (done) => {
+          it("compares objects using deep equality by default", (done) => {
             const Time = mockTimeSource();
 
             const actual = Time.diagram(
@@ -308,6 +308,72 @@ describe("@cycle/time", () => {
 
             Time.assertEqual(actual, expected);
             Time.run(done);
+          });
+
+          describe("custom equality functions", () => {
+            it("passes", (done) => {
+              const Time = mockTimeSource();
+
+              const actual = Time.diagram(
+                `---A---B---C---|`,
+                {
+                  A: {foo: 1, bar: 2},
+                  B: {foo: 2, bar: 4},
+                  C: {foo: 3, bar: 6}
+                }
+              );
+
+              const expected = Time.diagram(
+                `---X---Y---Z---|`,
+                {
+                  X: {foo: 1, bar: 3},
+                  Y: {foo: 2, bar: 4},
+                  Z: {foo: 3, bar: 6}
+                }
+              );
+
+              function comparator (actual, expected) {
+                return actual.foo === expected.foo
+              }
+
+              Time.assertEqual(actual, expected, comparator);
+              Time.run(done);
+            });
+
+            it("fails", (done) => {
+              const Time = mockTimeSource();
+
+              const actual = Time.diagram(
+                `---A---B---C---|`,
+                {
+                  A: {foo: 1, bar: 2},
+                  B: {foo: 2, bar: 4},
+                  C: {foo: 3, bar: 6}
+                }
+              );
+
+              const expected = Time.diagram(
+                `---X---Y---Z---|`,
+                {
+                  X: {foo: 5, bar: 3},
+                  Y: {foo: 2, bar: 4},
+                  Z: {foo: 3, bar: 6}
+                }
+              );
+
+              function comparator (actual, expected) {
+                return actual.foo === expected.foo
+              }
+
+              Time.assertEqual(actual, expected, comparator);
+              Time.run((err) => {
+                if(!err) {
+                  done(new Error('expected test to fail'));
+                } else {
+                  done();
+                }
+              });
+            });
           });
 
           it("logs unexpected errors", (done) => {

--- a/test/time.ts
+++ b/test/time.ts
@@ -314,7 +314,7 @@ describe("@cycle/time", () => {
             it("passes", (done) => {
               const Time = mockTimeSource();
 
-              const actual = Time.diagram(
+              const actual$ = Time.diagram(
                 `---A---B---C---|`,
                 {
                   A: {foo: 1, bar: 2},
@@ -323,7 +323,7 @@ describe("@cycle/time", () => {
                 }
               );
 
-              const expected = Time.diagram(
+              const expected$ = Time.diagram(
                 `---X---Y---Z---|`,
                 {
                   X: {foo: 1, bar: 3},
@@ -336,14 +336,14 @@ describe("@cycle/time", () => {
                 return actual.foo === expected.foo
               }
 
-              Time.assertEqual(actual, expected, comparator);
+              Time.assertEqual(actual$, expected$, comparator);
               Time.run(done);
             });
 
             it("fails", (done) => {
               const Time = mockTimeSource();
 
-              const actual = Time.diagram(
+              const actual$ = Time.diagram(
                 `---A---B---C---|`,
                 {
                   A: {foo: 1, bar: 2},
@@ -352,7 +352,7 @@ describe("@cycle/time", () => {
                 }
               );
 
-              const expected = Time.diagram(
+              const expected$ = Time.diagram(
                 `---X---Y---Z---|`,
                 {
                   X: {foo: 5, bar: 3},
@@ -365,13 +365,62 @@ describe("@cycle/time", () => {
                 return actual.foo === expected.foo
               }
 
-              Time.assertEqual(actual, expected, comparator);
+              Time.assertEqual(actual$, expected$, comparator);
+
               Time.run((err) => {
                 if(!err) {
                   done(new Error('expected test to fail'));
                 } else {
                   done();
                 }
+              });
+            });
+
+            it("logs errors", (done) => {
+              const Time = mockTimeSource();
+
+              const actual$ = Time.diagram(
+                `---A---B---C---|`,
+                {
+                  A: {foo: 1, bar: 2},
+                  B: {foo: 2, bar: 4},
+                  C: {foo: 3, bar: 6}
+                }
+              );
+
+              const expected$ = Time.diagram(
+                `---X---Y---Z---|`,
+                {
+                  X: {foo: 5, bar: 3},
+                  Y: {foo: 2, bar: 4},
+                  Z: {foo: 3, bar: 6}
+                }
+              );
+
+              function comparator (actual, expected) {
+                if (actual.foo !== expected.foo) {
+                  throw new Error("Something went wrong");
+                }
+              }
+
+              Time.assertEqual(actual$, expected$, comparator);
+
+              Time.run((err) => {
+                if (!err) {
+                  done(new Error("expected test to fail"));
+                }
+
+                assert(
+                  err.message.indexOf("Something went wrong") !== -1,
+                  [
+                    "Expected failure message to include error, did not:",
+                    err.message,
+                    "to include:",
+                    "Something went wrong"
+                  ].join('\n\n')
+                );
+
+                done();
               });
             });
           });

--- a/test/time.ts
+++ b/test/time.ts
@@ -1,11 +1,10 @@
 import * as assert from 'assert';
 import {mockTimeSource, timeDriver} from '../src/';
-import {mockDOMSource, makeHTMLDriver, div, button, VNode} from '@cycle/dom';
+import {mockDOMSource} from '@cycle/dom';
 import xs, {Stream} from 'xstream';
 import {setAdapt} from '@cycle/run/lib/adapt';
 import {Observable} from 'rxjs/Rx';
 import * as most from 'most';
-import * as htmlLooksLike from 'html-looks-like';
 
 const libraries = [
   {name: 'xstream', adapt: stream => stream, lib: xs},
@@ -29,89 +28,53 @@ function compose (stream, f) {
   throw new Error(`Don't know how to compose`);
 }
 
-// TODO:
-// - Put the counter boilerplate in its own file
-// - Remove unnecessary dependencies
-// - Any other cleanup
-// - Improve error messages
-// - Optimisation work
-
-function Counter ({DOM}) {
-  function view (count) {
-    return (
-      div('.counter', [
-        div('.count', `Count: ${count}`),
-        button('.subtract', '-'),
-        button('.add', '+')
-      ])
-    );
-  }
-
-  const add$ = DOM
-    .select('.add')
-    .events('click')
-    .mapTo(+1);
-
-  const subtract$ = DOM
-    .select('.subtract')
-    .events('click')
-    .mapTo(-1);
-
-  const change$ = xs.merge(add$, subtract$);
-
-  const add = (a, b) => a + b;
-
-  const count$ = change$.fold(add, 0);
-
-  return {
-    DOM: count$.map(view)
-  }
-}
-
-function toHTML (vtree$: Stream<VNode>) {
-  const htmlDriver = makeHTMLDriver(() => {});
-
-  return htmlDriver(vtree$, 'DOM').elements();
-}
-
 describe("@cycle/time", () => {
   before(() => setAdapt(stream => stream));
 
   it("can be used to test Cycle apps", (done) => {
+    function Counter ({DOM}) {
+      const add$ = DOM
+        .select('.add')
+        .events('click')
+        .mapTo(+1);
+
+      const subtract$ = DOM
+        .select('.subtract')
+        .events('click')
+        .mapTo(-1);
+
+      const change$ = xs.merge(add$, subtract$);
+
+      const add = (a, b) => a + b;
+
+      const count$ = change$.fold(add, 0);
+
+      return {
+        count$
+      }
+    }
+
     const Time = mockTimeSource();
 
-    const expectedHTML = (count: number) => `
-      <div class="counter">
-        {{ ... }}
-        <div class="count">Count: ${count}</div>
-        {{ ... }}
-      </div>
-    `;
+    const addClick      = '---x-x-x------x-|';
+    const subtractClick = '-----------x----|';
 
-    const addClick$      = Time.diagram('---x-x-x------x-|');
-    const subtractClick$ = Time.diagram('-----------x----|');
-
-    const expectedCount$ = Time.diagram('0--1-2-3---2--3-|');
-
-    const expectedHTML$  = expectedCount$.map(expectedHTML);
+    const expectedCount = '0--1-2-3---2--3-|';
 
     const DOM = mockDOMSource({
       '.add': {
-        'click': addClick$
+        'click': Time.diagram(addClick)
       },
       '.subtract': {
-        'click': subtractClick$
+        'click': Time.diagram(subtractClick)
       }
     });
 
     const counter = Counter({DOM});
 
-    const HTML$ = counter.DOM.compose(toHTML);
-
     Time.assertEqual(
-      HTML$,
-      expectedHTML$,
-      htmlLooksLike
+      counter.count$,
+      Time.diagram(expectedCount)
     );
 
     Time.run(done);
@@ -422,7 +385,7 @@ describe("@cycle/time", () => {
             });
           });
 
-          it("displays simultaneous events correctly", (done) => {
+          it("displays simultaneous events correcly", (done) => {
             const Time = mockTimeSource();
 
             const input    = `---(11)---(22)---(33)---|`;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
     "module": "commonjs",
     "declaration": true,
     "lib": [
+      "DOM",
       "ES5",
       "ES6"
     ]


### PR DESCRIPTION
Closes #19 by supporting custom equality functions such as `html-looks-like`.

TODOs:
- [X] Remove unnecessary dependencies & any other clean up
- [X] Improve how the error messages display
- [x] Test that failures from custom equality functions are raised & displayed
- [x] Write documentation
