### PR TITLE
Enhanced type definitions of MockTimeSource.diagram

### DIFF
--- a/src/time-source.ts
+++ b/src/time-source.ts
@@ -4,6 +4,10 @@ import {Frame} from './animation-frames';
 export type Operator = <T>(stream: Stream<T>) => Stream<T>;
 export type Comparator = (actual: any, expected: any) => void;
 
+export interface ObjectDictionary<T> {
+  [key: string]: T
+}
+
 export interface TimeSource {
   animationFrames (): Stream<Frame>;
   delay (delayTime: number): Operator;
@@ -14,7 +18,8 @@ export interface TimeSource {
 }
 
 export interface MockTimeSource extends TimeSource {
-  diagram (str: string, values?: Object): Stream<any>;
+  diagram<T> (str: string, values: ObjectDictionary<T>): Stream<T>;
+  diagram (str: string): Stream<number|string>;
   record (stream: Stream<any>): Stream<Array<any>>;
   assertEqual (actual: Stream<any>, expected: Stream<any>, comparator?: Comparator): void;
   run (cb?: (err?: Error) => void): void;


### PR DESCRIPTION
With this commit, the return type of `diagram` method is not `Stream<any>` anymore.

`diagram` method has now two signatures
- the first with one argument, returning `Stream<number|string>`
- the second with two arguments, with the latest a dictionary of values, returning `Stream<T>`

Possible issues : 
- Should the first signature return type be `Stream<number|string>` or `Stream<number>|Stream<string>` ?
- How are errors handled ?