### PR TITLE
Enhanced type definitions of MockTimeSource.diagram

### DIFF
--- a/src/time-source.ts
+++ b/src/time-source.ts
@@ -4,6 +4,10 @@ import {Frame} from './animation-frames';
 export type Operator = <T>(stream: Stream<T>) => Stream<T>;
 export type Comparator = (actual: any, expected: any) => void;
 
+export interface ObjectDictionary<T> {
+  [key: string]: T
+}
+
 export interface TimeSource {
   animationFrames (): Stream<Frame>;
   delay (delayTime: number): Operator;
@@ -14,7 +18,9 @@ export interface TimeSource {
 }
 
 export interface MockTimeSource extends TimeSource {
-  diagram (str: string, values?: Object): Stream<any>;
+  diagram<T> (str: string, values: ObjectDictionary<T>): Stream<T>;
+  diagram<T> (str: string, values: Array<T>): Stream<T>;
+  diagram (str: string): Stream<number>;
   record (stream: Stream<any>): Stream<Array<any>>;
   assertEqual (actual: Stream<any>, expected: Stream<any>, comparator?: Comparator): void;
   run (cb?: (err?: Error) => void): void;


### PR DESCRIPTION
diagram method has now three signatures with type inference for returned `Stream`
- the first with one argument, returning `Stream<number|string>`
- the second with two arguments, with the latest an `Array<T>` of values, returning `Stream<T>`
- the third with two arguments, with the latest a dictionary of values, returning `Stream<T>`